### PR TITLE
should resolve issue #2 - "Error when @media print encountered"

### DIFF
--- a/tasks/lib/stripmq.js
+++ b/tasks/lib/stripmq.js
@@ -26,6 +26,9 @@ Stringify.prototype.matchMedia = function(str) {
         queries = str.toLowerCase().match(/\((.+)\)/gi),
         matches = [];
 
+    if(!queries)
+        return;
+
     queries.forEach(function(query) {
         // min/max is should be the first property, then the name of the property (like width)
         var keyval = query.replace(/\(|\)/g, "").split(":"),


### PR DESCRIPTION
I had the same issue as simonsmith, when trying to flatten Zurb Foundation MQs. This allowed the iterator carry on after such an error.
