### PR TITLE
Ignore base CSS / prefix rules coming from mediaqueries

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # grunt-stripmq
 > Mobile-first CSS Fallback
 
+Fork of [jtangelder](https://github.com/jtangelder/grunt-stripmq), adding a switch to ignore base CSS.
+
 **grunt-stripmq** is a Grunt task to generate a fallback version of your fancy mobile first stylesheet. Since IE8 and lower dont support media queries, you can use a javascript library like respond.js to enable this, or generate a fallback version on build-time with this task.
 
 Here's the workflow:
@@ -165,6 +167,18 @@ Default value: Defaults to `options.width/options.height` if both are provided, 
 #### options['color']
 Type: `Integer`
 Default value: `3`
+
+#### options.ignoreBase
+Type: `Boolean`
+Default value: `false`
+
+#### options.prefixCSS
+Type: `String`
+Default value: `""`
+
+#### options.prefixWithSpace
+Type: `Boolean`
+Default value: `true
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Default value: Defaults to `options.width/options.height` if both are provided, 
 Type: `Integer`
 Default value: `3`
 
-#### options.removeBaseCss
+#### options.onlyMediaQueries
 Type: `Boolean`
 Default value: `false`
 

--- a/README.md
+++ b/README.md
@@ -166,17 +166,9 @@ Default value: Defaults to `options.width/options.height` if both are provided, 
 Type: `Integer`
 Default value: `3`
 
-#### options.ignoreBase
+#### options.removeBaseCss
 Type: `Boolean`
 Default value: `false`
-
-#### options.prefixCSS
-Type: `String`
-Default value: `""`
-
-#### options.prefixWithSpace
-Type: `Boolean`
-Default value: `true
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # grunt-stripmq
 > Mobile-first CSS Fallback
 
-Fork of [jtangelder](https://github.com/jtangelder/grunt-stripmq), adding a switch to ignore base CSS.
-
 **grunt-stripmq** is a Grunt task to generate a fallback version of your fancy mobile first stylesheet. Since IE8 and lower dont support media queries, you can use a javascript library like respond.js to enable this, or generate a fallback version on build-time with this task.
 
 Here's the workflow:

--- a/tasks/lib/stripmq.js
+++ b/tasks/lib/stripmq.js
@@ -11,7 +11,7 @@ function stripMediaQueries (ast, options) {
                 rules.push.apply(rules, rule.rules);
             }
         } else {
-            if (options.removeBaseCss !== true) {
+            if (options.onlyMediaQueries !== true) {
                 rules.push(rule);
             }
         }
@@ -28,16 +28,16 @@ function stripMediaQueries (ast, options) {
 function StripMQ (input, options) {
 
     options = {
-        type:            options.type || 'screen',
-        width:           options.width || 1024,
-        'device-width':  options['device-width'] || options.width || 1024,
-        height:          options.height || 768,
-        'device-height': options['device-height'] || options.height || 768,
-        resolution:      options.resolution || '1dppx',
-        orientation:     options.orientation || 'landscape',
-        'aspect-ratio':  options['aspect-ratio'] || options.width/options.height || 1024/768,
-        color:           options.color || 3,
-        removeBaseCss:   (options.removeBaseCss === true)
+        type:             options.type || 'screen',
+        width:            options.width || 1024,
+        'device-width':   options['device-width'] || options.width || 1024,
+        height:           options.height || 768,
+        'device-height':  options['device-height'] || options.height || 768,
+        resolution:       options.resolution || '1dppx',
+        orientation:      options.orientation || 'landscape',
+        'aspect-ratio':   options['aspect-ratio'] || options.width/options.height || 1024/768,
+        color:            options.color || 3,
+        onlyMediaQueries: (options.onlyMediaQueries === true)
     };
 
     var tree = parse(input);

--- a/tasks/lib/stripmq.js
+++ b/tasks/lib/stripmq.js
@@ -4,7 +4,7 @@ var parse = require('css-parse'),
     stringify = require('css-stringify'),
     mediaQuery = require('css-mediaquery');
 
-function prefixSelectors(options, rules){
+function prefixSelectors (options, rules){
     rules.forEach(function(rule){
         rule.selectors.forEach(function(selector, index){
             rule.selectors[index] = options.prefixCSS + (options.prefixWithSpace !== false ? ' ' : '') + selector;
@@ -13,7 +13,7 @@ function prefixSelectors(options, rules){
 }
 
 
-function stripMediaQueries(ast, options) {
+function stripMediaQueries (ast, options) {
     ast.stylesheet.rules = ast.stylesheet.rules.reduce(function(rules, rule) {
         if (rule.type === 'media') {
             if (mediaQuery.match(rule.media, options)) {
@@ -38,7 +38,7 @@ function stripMediaQueries(ast, options) {
  * @param   {string} input
  * @returns {string} output
  */
-function StripMQ(input, options) {
+function StripMQ (input, options) {
 
     options = {
         type:            options.type || 'screen',
@@ -48,7 +48,7 @@ function StripMQ(input, options) {
         'device-height': options['device-height'] || options.height || 768,
         resolution:      options.resolution || '1dppx',
         orientation:     options.orientation || 'landscape',
-        'aspect-ratio':  options['aspect-ratio'] || options.width / options.height || 1024 / 768,
+        'aspect-ratio':  options['aspect-ratio'] || options.width/options.height || 1024/768,
         color:           options.color || 3,
         ignoreBase:      (options.ignoreBase === true),
         prefixCSS:       options.prefixCSS || '',

--- a/tasks/lib/stripmq.js
+++ b/tasks/lib/stripmq.js
@@ -4,27 +4,14 @@ var parse = require('css-parse'),
     stringify = require('css-stringify'),
     mediaQuery = require('css-mediaquery');
 
-function prefixSelectors (options, rules){
-    rules.forEach(function(rule){
-        rule.selectors.forEach(function(selector, index){
-            rule.selectors[index] = options.prefixCSS + (options.prefixWithSpace !== false ? ' ' : '') + selector;
-        });
-    });
-}
-
-
 function stripMediaQueries (ast, options) {
     ast.stylesheet.rules = ast.stylesheet.rules.reduce(function(rules, rule) {
         if (rule.type === 'media') {
             if (mediaQuery.match(rule.media, options)) {
-                if(options.prefixCSS.length > 0){
-                    prefixSelectors(options,rule);
-                }
-
                 rules.push.apply(rules, rule.rules);
             }
         } else {
-            if (options.ignoreBase !== true) {
+            if (options.removeBaseCss !== true) {
                 rules.push(rule);
             }
         }
@@ -50,9 +37,7 @@ function StripMQ (input, options) {
         orientation:     options.orientation || 'landscape',
         'aspect-ratio':  options['aspect-ratio'] || options.width/options.height || 1024/768,
         color:           options.color || 3,
-        ignoreBase:      (options.ignoreBase === true),
-        prefixCSS:       options.prefixCSS || '',
-        prefixWithSpace: (options.prefixWithSpace !== false)
+        removeBaseCss:   (options.removeBaseCss === true)
     };
 
     var tree = parse(input);

--- a/tasks/lib/stripmq.js
+++ b/tasks/lib/stripmq.js
@@ -13,7 +13,9 @@ function stripMediaQueries (ast, options) {
             }
         }
         else {
-            rules.push(rule);
+            if(options.ignoreBase !== true){
+                rules.push(rule);
+            }
         }
         return rules;
     }, []);
@@ -36,7 +38,8 @@ function StripMQ(input, options) {
         resolution:      options.resolution || '1dppx',
         orientation:     options.orientation || 'landscape',
         'aspect-ratio':  options['aspect-ratio'] || options.width/options.height || 1024/768,
-        color:           options.color || 3
+        color:           options.color || 3,
+        ignoreBase:      options.ignoreBase || false
     };
 
     var tree = parse(input);

--- a/tasks/lib/stripmq.js
+++ b/tasks/lib/stripmq.js
@@ -4,12 +4,12 @@ var parse = require('css-parse'),
     stringify = require('css-stringify'),
     mediaQuery = require('css-mediaquery');
 
-function prefixSelectors(prefix, selectors){
-    selectors.forEach(function(val, idx, arr){
-        arr[idx] = prefix + val;
+function prefixSelectors(options, rules){
+    rules.forEach(function(rule){
+        rule.selectors.forEach(function(selector, index){
+            rule.selectors[index] = options.prefixCSS + (options.prefixWithSpace !== false ? ' ' : '') + selector;
+        });
     });
-
-    return selectors;
 }
 
 
@@ -17,18 +17,14 @@ function stripMediaQueries(ast, options) {
     ast.stylesheet.rules = ast.stylesheet.rules.reduce(function(rules, rule) {
         if (rule.type === 'media') {
             if (mediaQuery.match(rule.media, options)) {
-                if (options.prefixCSS.length > 0){
-                    rule.selectors = prefixSelectors(options.prefixCSS + (options.prefixWithSpace ? " " : ""), rule.selectors);
+                if(options.prefixCSS.length > 0){
+                    prefixSelectors(options,rule);
                 }
 
                 rules.push.apply(rules, rule.rules);
             }
         } else {
             if (options.ignoreBase !== true) {
-                if (options.prefixCSS.length > 0){
-                    rule.selectors = prefixSelectors(options.prefixCSS + (options.prefixWithSpace ? " " : ""), rule.selectors);
-                }
-
                 rules.push(rule);
             }
         }
@@ -54,9 +50,9 @@ function StripMQ(input, options) {
         orientation:     options.orientation || 'landscape',
         'aspect-ratio':  options['aspect-ratio'] || options.width / options.height || 1024 / 768,
         color:           options.color || 3,
-        ignoreBase:      options.ignoreBase === true,
+        ignoreBase:      (options.ignoreBase === true),
         prefixCSS:       options.prefixCSS || '',
-        prefixWithSpace: options.prefixWithSpace !== false
+        prefixWithSpace: (options.prefixWithSpace !== false)
     };
 
     var tree = parse(input);


### PR DESCRIPTION
I added a switch to ignore the base CSS outside of mediaqueries.

Also, I added an option to prefix every rule coming from a mediaquery with a string, so you could target for example the classes added by modernizr.
