### PR TITLE
Add clean-css options

### DIFF
--- a/tasks/stripmq.js
+++ b/tasks/stripmq.js
@@ -7,7 +7,7 @@ var fs = require("fs"),
 module.exports = function (grunt) {
     grunt.registerMultiTask("stripmq", "Strip media queries from stylesheets", function () {
         var options = this.options({
-            cleanCss: true
+            cleanCss: {}
         });
 
         // Iterate over all src-dest file pairs.
@@ -27,7 +27,7 @@ module.exports = function (grunt) {
                 var result = stripMq(input, options);
 
                 if(options.cleanCss) {
-                    result = new CleanCss().minify(result);
+                    result = new CleanCss(options.cleanCss).minify(result);
                 }
 
                 grunt.file.write(f.dest, result);


### PR DESCRIPTION
Example of new configuration:

```
grunt.initConfig({
    stripmq: {
        //Viewport options
        options: {
            width: 1000,
            type: 'screen',
            cleanCss: {
                compatibility: 'ie8',
                keepBreaks: true,
                noAdvanced: true
            }
        },
        all: {
            files: {
                //follows the pattern 'destination': ['source']
                'css/app-old-ie.css': ['css/app.css']
            }
        }
    }
});
```