### PR TITLE
Update README.md to include hidden clean-css option

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ Default value: Defaults to `options.width/options.height` if both are provided, 
 Type: `Integer`
 Default value: `3`
 
+#### options['cleanCss']
+Type: `Boolean`
+Default value: `true` If `true`, CSS is cleaned with clean-css merging selectors and properties.
+
 ## Contributing
 
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using Grunt.


### PR DESCRIPTION
Hey, I noticed that when using this tool the clean-css step was removing IE specific CSS hacks which was causing display issues for me in IE. I've therefore switched off the cleanCss option, but noticed that the option wasn't mentioned in the docs. If there was valid reasoning for not putting this in the readme fair enough but thought it worth adding incase anyone else hits this issue.
