### PR TITLE
Show error message on fail

### DIFF
--- a/tasks/stripmq.js
+++ b/tasks/stripmq.js
@@ -34,7 +34,7 @@ module.exports = function (grunt) {
                 grunt.log.writeln('File "' + f.dest + '" created.');
             }
             catch (e) {
-                var err = new Error('Stripping media queries failed.');
+                var err = new Error('Stripping media queries failed: ' + e.toString());
                 if (e.msg) {
                     err.message += ', ' + e.msg + '.';
                 }


### PR DESCRIPTION
Fix for issue #31, simply adding a line number can help devs find where the code is going wrong.
